### PR TITLE
Added gzip support

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -37,13 +37,12 @@ func (h HeadersFlagValue) Set(value string) error {
 	if value == "" {
 		return nil
 	}
-
 	split := strings.Split(value, ":")
 	if len(split) < 2 {
 		return fmt.Errorf(`format should be "k:v"`)
 	}
-
-	h[http.CanonicalHeaderKey(split[0])] = split[1]
+	trim := func(s string) string { return strings.Trim(s, " \t\n\r") }
+	h[http.CanonicalHeaderKey(trim(split[0]))] = trim(strings.Join(split[1:], ":"))
 	return nil
 }
 
@@ -93,7 +92,9 @@ func makeRequest(params GetParams, method string, body io.Reader, length int) (e
 
 	// Add headers
 	req.Headers.AddAll(params.Headers)
-	req.Headers.Add("Content-Length", fmt.Sprintf("%v", length))
+	if strings.ToLower(method) != GET {
+		req.Headers.Add("Content-Length", fmt.Sprintf("%v", length))
+	}
 
 	r, err := ecurl.Do(req)
 	if err != nil {

--- a/ecurl.go
+++ b/ecurl.go
@@ -1,10 +1,24 @@
 package main
 
-import (
-	"github.com/obonobo/ecurl/cmd"
-)
+import "github.com/obonobo/ecurl/cmd"
 
 // This main function just runs the CLI
 func main() {
+	// con, err := net.Dial("tcp", "golang.org:80")
+	// if err != nil {
+	// 	panic(err)
+	// }
+
+	// _, err = con.Write([]byte("GET / HTTP/1.1\r\nUser-Agent: ecurl/0.1.0\r\nAccept: */*\r\nConnection: close\r\n\r\n"))
+	// if err != nil {
+	// 	panic(err)
+	// }
+
+	// res, err := ioutil.ReadAll(con)
+	// if err != nil {
+	// 	panic(err)
+	// }
+
+	// fmt.Println(string(res))
 	cmd.RunAndExit()
 }

--- a/ecurl/buffered_scanner_test.go
+++ b/ecurl/buffered_scanner_test.go
@@ -1,0 +1,80 @@
+package ecurl
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+)
+
+// Tests BufferedScanner.Read() with various inputs
+func TestBufferedScannerRead(t *testing.T) {
+	// Some basic buffer sizes to use for testing
+	bufsizes := func() []int {
+		return []int{
+			1, 1 << 1, 1 << 2,
+			1 << 4, 1 << 6, 1 << 10,
+			1 << 20, 1 << 27,
+		}
+	}
+
+	for _, tc := range []struct {
+		name     string
+		input    string
+		bufsizes []int
+	}{
+		{
+			name:     "empty",
+			input:    "",
+			bufsizes: bufsizes(),
+		},
+		{
+			name:     "hello world",
+			input:    "Hello world!",
+			bufsizes: bufsizes(),
+		},
+		{
+			name:     "lorem ipsum",
+			bufsizes: bufsizes(),
+			input: `
+			Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor
+			incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis
+			nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+			Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu
+			fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in
+			culpa qui officia deserunt mollit anim id est laborum.
+			`,
+		},
+		{
+			name:     "big",
+			input:    strings.Repeat("big!\n", 1000),
+			bufsizes: bufsizes(),
+		},
+
+		{
+			name:     "very big",
+			input:    strings.Repeat("very big!\n", 1<<10),
+			bufsizes: bufsizes(),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for _, size := range tc.bufsizes {
+				size := size
+				t.Run(fmt.Sprintf("size=%v", size), func(t *testing.T) {
+					t.Parallel()
+					r := bytes.NewBufferString(tc.input)
+					scnr := &BufferedScanner{reader: r, buf: buffer{make([]byte, 0, size), 0}}
+					red, err := io.ReadAll(scnr)
+					if err != nil {
+						t.Fatalf("Expected scanner not to return an error but got: %v", err)
+					}
+					if actual, expected := string(red), tc.input; actual != expected {
+						t.Fatalf("Expected scanner to return '%v' but got '%v'", expected, actual)
+					}
+				})
+			}
+		})
+	}
+}

--- a/ecurl/chunked_reader.go
+++ b/ecurl/chunked_reader.go
@@ -91,7 +91,7 @@ func (c *chunkedReader) loadNextChunk() error {
 		return c.err
 	}
 
-	// Parse the chunk length
+	// Parse the chunk length - its hexadecimal btw
 	len, err := strconv.ParseInt(string(line), 16, 64)
 	if err != nil {
 		c.err = fmt.Errorf("malformed chunk: %w", err)

--- a/ecurl/content_length_reader.go
+++ b/ecurl/content_length_reader.go
@@ -5,9 +5,7 @@ import (
 	"net"
 )
 
-// A Content-Length limited io.ReadCloser that wraps the raw TCP connection. The
-// contentLengthReader will use buf as a buffer while reading - it will read from the socket
-// in chunks of length len(buf.b), and will return io.EOF once it has read up to
+// A Content-Length limited io.ReadCloser that wraps the raw TCP connection
 type contentLengthReader struct {
 	conn net.Conn         // TCP connection
 	scnr *BufferedScanner // Scanner for reading from TCP connection

--- a/ecurl/gzip.go
+++ b/ecurl/gzip.go
@@ -1,0 +1,28 @@
+package ecurl
+
+import (
+	"compress/gzip"
+	"io"
+)
+
+// A decoder for gzipped response data. Use by wrapping the outermost io.Reader
+// in the Gzipper. This decoding should be applied AFTER the transfer coding
+// reader (i.e. after the chunkedReader)
+type Gzipper struct {
+	r io.ReadCloser
+	g *gzip.Reader
+}
+
+func NewGzipper(r io.ReadCloser) (*Gzipper, error) {
+	g, err := gzip.NewReader(r)
+	return &Gzipper{r, g}, err
+}
+
+// Read + decode gzip data at the same time
+func (z *Gzipper) Read(b []byte) (int, error) {
+	return z.g.Read(b)
+}
+
+func (z *Gzipper) Close() error {
+	return z.r.Close()
+}

--- a/ecurl/gzip_test.go
+++ b/ecurl/gzip_test.go
@@ -1,0 +1,55 @@
+package ecurl
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/obonobo/ecurl/internal/testutils"
+)
+
+// Tests decoding a basic gzip encoded string
+func TestDecodeBasic(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "empty",
+			input: "",
+		},
+		{
+			name:  "hello world",
+			input: "Hello World!",
+		},
+		{
+			name:  "asd123",
+			input: "asd123",
+		},
+		{
+			name:  "big!",
+			input: strings.Repeat("big!\r\n\t", 1024),
+		},
+	} {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			zipped, err := testutils.Gzipup(tc.input)
+			if err != nil {
+				t.Fatalf("Failed to gzip string '%v': %v", tc.input, err)
+			}
+			gzipper, err := NewGzipper(io.NopCloser(bytes.NewBufferString(zipped)))
+			if err != nil {
+				t.Fatalf("Failed to create gzipper: %v", err)
+			}
+			red, err := io.ReadAll(gzipper)
+			if err != nil {
+				t.Fatalf("Failed to read from gzipper: %v", err)
+			}
+			if expected, actual := tc.input, string(red); expected != actual {
+				t.Fatalf("Expected '%v' but got '%v'", expected, actual)
+			}
+		})
+	}
+}

--- a/ecurl/infinite_reader.go
+++ b/ecurl/infinite_reader.go
@@ -16,8 +16,9 @@ func (r *infiniteReader) Close() error {
 
 func (r *infiniteReader) Read(b []byte) (int, error) {
 	n, err := r.scnr.Read(b)
-
-	// If we get some data then give the server another 5 seconds
-	r.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if err == nil {
+		// If we get some data then give the server another 5 seconds
+		r.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	}
 	return n, err
 }

--- a/ecurl/multipart_byteranges_reader.go
+++ b/ecurl/multipart_byteranges_reader.go
@@ -2,16 +2,16 @@ package ecurl
 
 import "net"
 
-type multipartByterangesReader struct {
+type multipartByteRangesReader struct {
 	conn net.Conn
 	scnr *BufferedScanner
 	err  error
 }
 
-func (r *multipartByterangesReader) Close() error {
+func (r *multipartByteRangesReader) Close() error {
 	return r.conn.Close()
 }
 
-func (r *multipartByterangesReader) Read(b []byte) (int, error) {
+func (r *multipartByteRangesReader) Read(b []byte) (int, error) {
 	return 0, nil
 }

--- a/ecurl/request.go
+++ b/ecurl/request.go
@@ -6,6 +6,13 @@ import (
 	"strings"
 )
 
+var defaultHeaders = Headers{
+	"User-Agent":      "ecurl/0.1.0", // Custom user agent
+	"Accept":          "*/*",         // By default we will accept anything
+	"Accept-Encoding": "gzip",        // By default we can accept gzip
+	"Connection":      "close",       // This tool doesn't really need to make more requests
+}
+
 type Request struct {
 	Method  string
 	Host    string
@@ -18,43 +25,66 @@ type Request struct {
 func (r *Request) String() string {
 	return fmt.Sprintf(""+
 		"Request[Method=%v, Host=%v, "+
-		"Path=%v, Port=%v, headers=%v, Body=%v]",
+		"Path=%v, Port=%v, Headers=%v, Body=%v]",
 		r.Method, r.Host, r.Path, r.Port, r.Headers, r.Body)
 }
 
+// Creates a new Request with some computed default headers
 func NewRequest(method string, url string, body io.Reader) (*Request, error) {
-	method = strings.ToUpper(method)
-	if !isAcceptableMethod(method) {
-		return nil, UnsupportedHttpMethod(method)
-	}
-
-	_, host, path, port, err := splitUrl(url)
+	r, host, err := newBlankRequest(method, url, body)
 	if err != nil {
-		return nil, fmt.Errorf("error parsing url: %w", err)
+		return r, err
 	}
 
-	r := &Request{
-		Method: method,
-		Port:   port,
-		Path:   path,
-		Host:   host,
-		Body:   body,
-
-		// Request comes with some default headers...
-		Headers: Headers{
-			"User-Agent": "curl/7.68.0", // Pretending we are curl
-			"Accept":     "*/*",         // By default we will accept anything
-			"Host":       host,          // Computes host header from params
-		},
-	}
+	// Request comes with some default headers...
+	r.Headers.AddAll(defaultHeaders)
+	r.Headers.Add("Host", host)
 
 	// If the body is of a type that supports reporting its length, then we can
 	// automatically compute the Content-Length header
 	if x, ok := body.(interface{ Len() int }); ok {
 		r.Headers.Add("Content-Length", fmt.Sprintf("%v", x.Len()))
-	} else if body == nil {
+	} else if body == nil && strings.ToUpper(method) != GET {
 		r.Headers.Add("Content-Length", "0")
 	}
 
 	return r, nil
+}
+
+// Creates a new Request with no headers attached. Use the above NewRequest
+// function to auto-compute some useful client headers
+func NewBlankRequest(method string, url string, body io.Reader) (*Request, error) {
+	r, _, err := newBlankRequest(method, url, body)
+	return r, err
+}
+
+func newBlankRequest(
+	method string,
+	url string,
+	body io.Reader,
+) (
+	r *Request,
+	host string,
+	err error,
+) {
+	method = strings.ToUpper(method)
+	if !isAcceptableMethod(method) {
+		return nil, "", UnsupportedHttpMethod(method)
+	}
+
+	_, host, path, port, err := splitUrl(url)
+	if err != nil {
+		return nil, "", fmt.Errorf("error parsing url: %w", err)
+	}
+
+	r = &Request{
+		Method:  method,
+		Port:    port,
+		Path:    path,
+		Host:    host,
+		Body:    body,
+		Headers: make(Headers, 20),
+	}
+
+	return r, host, nil
 }


### PR DESCRIPTION
Client library now supports decoding gzip responses. If the server sends a
response containing the `Content-Encoding: gzip` header, the client will attach
a gzip decoder to the response body reader.
